### PR TITLE
Add Kafka bridge support and related documentation

### DIFF
--- a/.cursor/rules/documentation.mdc
+++ b/.cursor/rules/documentation.mdc
@@ -36,6 +36,7 @@ Do not duplicate tutorial content in features.md — link to the relevant guide 
 | Transport schemes, TLS, versions, SPI | [advanced-topics.md](../../docs/advanced-topics.md), [client-guide.md](../../docs/client-guide.md) |
 | New doc file or learning path | [docs/README.md](../../docs/README.md), [README.md](../../README.md) doc table |
 | STOMP terms or invariants | [domain-specification.md](../../docs/domain-specification.md) |
+| Kafka bridge API, config, mapping, deployment | [kafka-bridge-guide.md](../../docs/kafka-bridge-guide.md) — see [stomp4j-kafka-bridge.mdc](stomp4j-kafka-bridge.mdc) |
 | Internal architecture only | [ARCHITECTURE.md](../../ARCHITECTURE.md) — not user guides |
 
 ## Complexity order (do not invert)

--- a/.cursor/rules/stomp4j-kafka-bridge.mdc
+++ b/.cursor/rules/stomp4j-kafka-bridge.mdc
@@ -1,0 +1,37 @@
+---
+description: Keep Kafka Bridge code, config, and docs in sync
+alwaysApply: true
+---
+
+# Kafka Bridge — read and maintain
+
+The STOMP ↔ Kafka bridge lives in `bridge/` and [docs/kafka-bridge-guide.md](../../docs/kafka-bridge-guide.md).
+
+## Before changing bridge behaviour or public API
+
+1. Read [docs/kafka-bridge-guide.md](../../docs/kafka-bridge-guide.md) and [docs/domain-specification.md](../../docs/domain-specification.md) (Bridge terms).
+2. Place code in `bridge/stomp4j-kafka-bridge` (library) or `bridge/stomp4j-kafka-bridge-runner` (executable).
+3. Keep Kafka dependencies confined to `bridge/` modules — not in `commons`, `client`, or `server` production code.
+
+## Mandatory updates (same change)
+
+| Trigger | Action |
+|---------|--------|
+| New/changed `StompKafkaBridge` API | [kafka-bridge-guide.md](../../docs/kafka-bridge-guide.md) |
+| New/changed config keys or env vars | [kafka-bridge-guide.md](../../docs/kafka-bridge-guide.md) + runner `application.properties` |
+| New/changed mapping semantics | [kafka-bridge-guide.md](../../docs/kafka-bridge-guide.md), bridge unit tests |
+| User-visible capability add/remove/change | [features.md](../../docs/features.md) Bridge section |
+| New bridge domain terms | [domain-specification.md](../../docs/domain-specification.md) |
+| Module boundary / dependency change | [ARCHITECTURE.md](../../ARCHITECTURE.md) |
+| Subscription lifecycle used by bridge | Server tests + bridge integration tests |
+
+## Finish gate
+
+- `mvn verify` (Docker required for bridge integration tests)
+- Update [features.md](../../docs/features.md) when capabilities change
+
+## Related
+
+- [documentation.mdc](documentation.mdc)
+- [stomp4j-module-architecture.mdc](stomp4j-module-architecture.mdc)
+- [development-experience.mdc](development-experience.mdc)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,5 +36,6 @@ Read these before changing code or tests:
 | `domain-model.mdc` | Domain language alignment |
 | `stomp-protocol-compliance.mdc` | Normative STOMP spec compliance |
 | `documentation.mdc` | Keep README, features page, and docs/ in sync with API |
+| `stomp4j-kafka-bridge.mdc` | Keep Kafka bridge code, config, and docs in sync |
 | `stomp4j-tooling-languages.mdc` | Scripts: bash/JBang only |
 | `static-analysis.mdc` | Finish gate: `mvn verify` |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@ Stomp4J is a **Java 21 library** (not a runnable application) that implements th
 | License | Apache 2.0 |
 | Logging | SLF4J (consumer provides implementation) |
 
-Published artifacts: `stomp4j-commons`, `stomp4j-client`, `stomp4j-server`, `stomp4j-spring-boot-autoconfigure`, `stomp4j-spring-boot-starter-client`, `stomp4j-spring-boot-starter-server`, `stomp4j-quarkus-cdi`, `stomp4j-quarkus-client`, `stomp4j-quarkus-client-deployment`, `stomp4j-quarkus-server`, `stomp4j-quarkus-server-deployment`.
+Published artifacts: `stomp4j-commons`, `stomp4j-client`, `stomp4j-server`, `stomp4j-kafka-bridge`, `stomp4j-kafka-bridge-runner`, `stomp4j-spring-boot-autoconfigure`, `stomp4j-spring-boot-starter-client`, `stomp4j-spring-boot-starter-server`, `stomp4j-quarkus-cdi`, `stomp4j-quarkus-client`, `stomp4j-quarkus-client-deployment`, `stomp4j-quarkus-server`, `stomp4j-quarkus-server-deployment`.
 
 ## 2. Module dependency graph
 
@@ -38,9 +38,12 @@ stomp4j-parent
         ├── stomp4j-quarkus-server
         ├── stomp4j-quarkus-server-deployment
         └── stomp4j-quarkus-server-integration-tests
+    └── stomp4j-bridge      → optional Kafka bridge layer
+        ├── stomp4j-kafka-bridge        → server, kafka-clients
+        └── stomp4j-kafka-bridge-runner → kafka-bridge (executable)
 ```
 
-Dependencies flow **downward only**: `client` and `server` depend on `commons`; `server` tests may use `client` but production `server` does not depend on `client`. Quarkus extensions depend on `client` or `server` respectively, not on each other.
+Dependencies flow **downward only**: `client` and `server` depend on `commons`; `server` tests may use `client` but production `server` does not depend on `client`. `stomp4j-kafka-bridge` depends on `stomp4j-server` only (not `client`) in production; tests use `stomp4j-client`. Quarkus extensions depend on `client` or `server` respectively, not on each other.
 
 ## 3. Module responsibilities
 
@@ -144,9 +147,20 @@ Optional Quarkus 3.17 layer using CDI Events (no `*Template` APIs). No `module-i
 
 User guide: [docs/quarkus-guide.md](docs/quarkus-guide.md).
 
+### 3.5 Kafka bridge (`stomp4j-bridge`)
+
+Optional STOMP ↔ Kafka routing. Depends on `stomp4j-server` + `kafka-clients` only in production.
+
+| Module | Role |
+|--------|------|
+| `stomp4j-kafka-bridge` | `StompKafkaBridge`, `DestinationMapping`, `KafkaBridgeConfig` |
+| `stomp4j-kafka-bridge-runner` | `StompKafkaBridgeApplication` fat JAR |
+
+User guide: [docs/kafka-bridge-guide.md](docs/kafka-bridge-guide.md).
+
 ## 4. Public API entry points
 
-There is no `main()`. Consumers use:
+There is no `main()` in core modules. Consumers use:
 
 ### Client
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Read in order of complexity — each level builds on the previous one.
 | **Intermediate** | [docs/server-guide.md](docs/server-guide.md) | Handlers, outbound push, authentication |
 | **Intermediate** | [docs/spring-guide.md](docs/spring-guide.md) | Spring Boot starters and samples |
 | **Intermediate** | [docs/quarkus-guide.md](docs/quarkus-guide.md) | Quarkus extensions and CDI Events |
+| **Intermediate** | [docs/kafka-bridge-guide.md](docs/kafka-bridge-guide.md) | STOMP ↔ Kafka bridge (library, JAR, Docker) |
 | **Advanced** | [docs/advanced-topics.md](docs/advanced-topics.md) | Protocol versions, SPI, JPMS, wire format |
 
 Full index: [docs/README.md](docs/README.md)
@@ -74,6 +75,8 @@ Full index: [docs/README.md](docs/README.md)
 | `stomp4j-spring-boot-starter-server` | Spring Boot app embedding a STOMP server |
 | `stomp4j-quarkus-client` | Quarkus app connecting to an external broker (CDI Events) |
 | `stomp4j-quarkus-server` | Quarkus app embedding a STOMP server |
+| `stomp4j-kafka-bridge` | Embed STOMP ↔ Kafka routing in your app |
+| `stomp4j-kafka-bridge-runner` | Run the bridge as a standalone process (`java -jar`) |
 
 Details: [docs/overview.md#modules](docs/overview.md#modules)
 

--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.vepo</groupId>
+        <artifactId>stomp4j-parent</artifactId>
+        <version>1.1.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>stomp4j-bridge</artifactId>
+    <packaging>pom</packaging>
+    <name>Stomp4J :: Bridge</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>dev.vepo</groupId>
+                <artifactId>stomp4j-kafka-bridge</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>stomp4j-kafka-bridge</module>
+        <module>stomp4j-kafka-bridge-runner</module>
+    </modules>
+</project>

--- a/bridge/stomp4j-kafka-bridge-runner/pom.xml
+++ b/bridge/stomp4j-kafka-bridge-runner/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.vepo</groupId>
+        <artifactId>stomp4j-bridge</artifactId>
+        <version>1.1.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>stomp4j-kafka-bridge-runner</artifactId>
+    <name>Stomp4J :: Kafka Bridge Runner</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.vepo</groupId>
+            <artifactId>stomp4j-kafka-bridge</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.21</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>dev.vepo.stomp4j.bridge.runner.StompKafkaBridgeApplication</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>dev.vepo.stomp4j.bridge.runner.StompKafkaBridgeApplication</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/bridge/stomp4j-kafka-bridge-runner/src/main/java/dev/vepo/stomp4j/bridge/runner/BridgeConfigLoader.java
+++ b/bridge/stomp4j-kafka-bridge-runner/src/main/java/dev/vepo/stomp4j/bridge/runner/BridgeConfigLoader.java
@@ -1,0 +1,131 @@
+package dev.vepo.stomp4j.bridge.runner;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+import dev.vepo.stomp4j.bridge.DestinationMapper;
+import dev.vepo.stomp4j.bridge.DestinationMapping;
+import dev.vepo.stomp4j.bridge.KafkaBridgeConfig;
+import dev.vepo.stomp4j.bridge.StompKafkaBridge;
+import dev.vepo.stomp4j.commons.TransportType;
+
+public final class BridgeConfigLoader {
+
+    private static Map<String, String> explicitMappings(Properties properties) {
+        var mappings = new HashMap<String, String>();
+        properties.forEach((key, value) -> {
+            var propertyKey = key.toString();
+            if (propertyKey.startsWith("bridge.mapping.")) {
+                mappings.put(propertyKey.substring("bridge.mapping.".length()), value.toString());
+            }
+        });
+        return mappings;
+    }
+
+    private static boolean isReservedKafkaEnv(String key) {
+        return "KAFKA_BOOTSTRAP_SERVERS".equals(key)
+                || "KAFKA_CONSUMER_GROUP_ID".equals(key)
+                || "KAFKA_POLL_TIMEOUT_MS".equals(key);
+    }
+
+    private static Map<String, String> kafkaProperties(Properties properties) {
+        var kafkaProperties = new HashMap<String, String>();
+        properties.forEach((key, value) -> {
+            var propertyKey = key.toString();
+            if (propertyKey.startsWith("bridge.kafka.property.")) {
+                kafkaProperties.put(propertyKey.substring("bridge.kafka.property.".length()), value.toString());
+            } else if (propertyKey.startsWith("KAFKA_") && !isReservedKafkaEnv(propertyKey)) {
+                kafkaProperties.put(propertyKey.substring("KAFKA_".length()).toLowerCase().replace('_', '.'), value.toString());
+            }
+        });
+        return kafkaProperties;
+    }
+
+    public static StompKafkaBridge load() {
+        var properties = loadProperties();
+        var kafkaBuilder = KafkaBridgeConfig.builder()
+                                            .bootstrapServers(required(properties, "KAFKA_BOOTSTRAP_SERVERS", "bridge.kafka.bootstrap-servers"))
+                                            .consumerGroupId(property(properties,
+                                                                      "KAFKA_CONSUMER_GROUP_ID",
+                                                                      "bridge.kafka.consumer-group-id",
+                                                                      "stomp4j-bridge"))
+                                            .pollTimeoutMs(Long.parseLong(property(properties,
+                                                                                   "KAFKA_POLL_TIMEOUT_MS",
+                                                                                   "bridge.kafka.poll-timeout-ms",
+                                                                                   "1000")));
+        var dlqTopic = property(properties, "BRIDGE_DLQ_TOPIC", "bridge.dlq.topic", null);
+        if (Objects.nonNull(dlqTopic) && !dlqTopic.isBlank()) {
+            kafkaBuilder.dlqTopic(dlqTopic);
+        }
+        kafkaProperties(properties).forEach(kafkaBuilder::kafkaProperty);
+
+        var topicPrefixStrip = property(properties, "TOPIC_PREFIX_STRIP", "bridge.topic.prefix-strip", "/topic/");
+        var destinationPrefix = property(properties, "DESTINATION_PREFIX", "bridge.destination.prefix", topicPrefixStrip);
+        var explicitMappings = explicitMappings(properties);
+
+        DestinationMapper destinationMapper = explicitMappings.isEmpty()
+                                                                         ? DestinationMapping.prefix(topicPrefixStrip)
+                                                                         : DestinationMapping.composite(DestinationMapping.explicit(explicitMappings),
+                                                                                                        DestinationMapping.prefix(topicPrefixStrip));
+
+        var bridgeBuilder = StompKafkaBridge.builder()
+                                            .kafkaConfig(kafkaBuilder.build())
+                                            .destinationMapping(destinationMapper)
+                                            .allowedDestinationPrefix(destinationPrefix)
+                                            .serverName(property(properties, "STOMP_SERVER_NAME", "bridge.stomp.server-name", "stomp4j-kafka-bridge"))
+                                            .heartbeat(Duration.ofSeconds(Long.parseLong(property(properties,
+                                                                                                  "STOMP_HEARTBEAT_SECONDS",
+                                                                                                  "bridge.stomp.heartbeat-seconds",
+                                                                                                  "30"))))
+                                            .channel(TransportType.TCP,
+                                                     Integer.parseInt(property(properties, "STOMP_TCP_PORT", "bridge.stomp.tcp-port", "61613")))
+                                            .channel(TransportType.WEB_SOCKET,
+                                                     Integer.parseInt(property(properties, "STOMP_WS_PORT", "bridge.stomp.ws-port", "61614")));
+
+        var username = property(properties, "STOMP_AUTH_USERNAME", "bridge.stomp.auth.username", null);
+        var password = property(properties, "STOMP_AUTH_PASSWORD", "bridge.stomp.auth.password", null);
+        if (Objects.nonNull(username) && !username.isBlank()) {
+            var expectedPassword = Objects.requireNonNullElse(password, "");
+            bridgeBuilder.authenticator(credentials -> username.equals(credentials.username())
+                    && expectedPassword.equals(credentials.password()));
+        }
+
+        return bridgeBuilder.start();
+    }
+
+    private static Properties loadProperties() {
+        var properties = new Properties();
+        try (InputStream stream = BridgeConfigLoader.class.getClassLoader().getResourceAsStream("application.properties")) {
+            if (Objects.nonNull(stream)) {
+                properties.load(stream);
+            }
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+        return properties;
+    }
+
+    private static String property(Properties properties, String envKey, String propertyKey, String defaultValue) {
+        var envValue = System.getenv(envKey);
+        if (Objects.nonNull(envValue)) {
+            return envValue;
+        }
+        return properties.getProperty(propertyKey, defaultValue);
+    }
+
+    private static String required(Properties properties, String envKey, String propertyKey) {
+        var value = property(properties, envKey, propertyKey, null);
+        if (Objects.isNull(value) || value.isBlank()) {
+            throw new IllegalArgumentException("Missing required configuration: %s / %s".formatted(envKey, propertyKey));
+        }
+        return value;
+    }
+
+    private BridgeConfigLoader() {}
+}

--- a/bridge/stomp4j-kafka-bridge-runner/src/main/java/dev/vepo/stomp4j/bridge/runner/StompKafkaBridgeApplication.java
+++ b/bridge/stomp4j-kafka-bridge-runner/src/main/java/dev/vepo/stomp4j/bridge/runner/StompKafkaBridgeApplication.java
@@ -1,0 +1,24 @@
+package dev.vepo.stomp4j.bridge.runner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import dev.vepo.stomp4j.bridge.StompKafkaBridge;
+
+public final class StompKafkaBridgeApplication {
+
+    private static final Logger logger = LoggerFactory.getLogger(StompKafkaBridgeApplication.class);
+
+    public static void main(String[] args) throws InterruptedException {
+        try (var bridge = BridgeConfigLoader.load()) {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                logger.info("Shutting down STOMP-Kafka bridge");
+                bridge.close();
+            }));
+            logger.info("STOMP-Kafka bridge started");
+            bridge.awaitShutdown();
+        }
+    }
+
+    private StompKafkaBridgeApplication() {}
+}

--- a/bridge/stomp4j-kafka-bridge-runner/src/main/java/module-info.java
+++ b/bridge/stomp4j-kafka-bridge-runner/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module stomp4j.kafka.bridge.runner {
+    requires stomp4j.kafka.bridge;
+    requires org.slf4j;
+}

--- a/bridge/stomp4j-kafka-bridge-runner/src/main/resources/application.properties
+++ b/bridge/stomp4j-kafka-bridge-runner/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+bridge.kafka.bootstrap-servers=localhost:9092
+bridge.kafka.consumer-group-id=stomp4j-bridge
+bridge.destination.prefix=/topic/
+bridge.topic.prefix-strip=/topic/
+bridge.stomp.tcp-port=61613
+bridge.stomp.ws-port=61614

--- a/bridge/stomp4j-kafka-bridge/pom.xml
+++ b/bridge/stomp4j-kafka-bridge/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.vepo</groupId>
+        <artifactId>stomp4j-bridge</artifactId>
+        <version>1.1.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>stomp4j-kafka-bridge</artifactId>
+    <name>Stomp4J :: Kafka Bridge</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.vepo</groupId>
+            <artifactId>stomp4j-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.vepo</groupId>
+            <artifactId>stomp4j-client</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/DestinationMapper.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/DestinationMapper.java
@@ -1,0 +1,8 @@
+package dev.vepo.stomp4j.bridge;
+
+import java.util.Optional;
+
+public interface DestinationMapper {
+
+    Optional<String> toKafkaTopic(String stompDestination);
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/DestinationMapping.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/DestinationMapping.java
@@ -1,0 +1,35 @@
+package dev.vepo.stomp4j.bridge;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import dev.vepo.stomp4j.bridge.internal.CompositeDestinationMapper;
+import dev.vepo.stomp4j.bridge.internal.ExplicitDestinationMapper;
+import dev.vepo.stomp4j.bridge.internal.PrefixDestinationMapper;
+
+public final class DestinationMapping {
+
+    public static DestinationMapper composite(DestinationMapper first, DestinationMapper... rest) {
+        Objects.requireNonNull(first, "first");
+        var mappers = new ArrayList<DestinationMapper>();
+        mappers.add(first);
+        if (Objects.nonNull(rest)) {
+            for (var mapper : rest) {
+                mappers.add(Objects.requireNonNull(mapper, "mapper"));
+            }
+        }
+        return new CompositeDestinationMapper(List.copyOf(mappers));
+    }
+
+    public static DestinationMapper explicit(Map<String, String> stompToKafka) {
+        return new ExplicitDestinationMapper(stompToKafka);
+    }
+
+    public static DestinationMapper prefix(String prefix) {
+        return new PrefixDestinationMapper(prefix);
+    }
+
+    private DestinationMapping() {}
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/KafkaBridgeConfig.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/KafkaBridgeConfig.java
@@ -1,0 +1,133 @@
+package dev.vepo.stomp4j.bridge;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public final class KafkaBridgeConfig {
+
+    public static final class Builder {
+        private String bootstrapServers;
+        private String consumerGroupId = "stomp4j-bridge";
+        private String dlqTopic;
+        private long pollTimeoutMs = 1000L;
+        private final Map<String, String> kafkaProperties = new HashMap<>();
+
+        public Builder bootstrapServers(String bootstrapServers) {
+            this.bootstrapServers = bootstrapServers;
+            return this;
+        }
+
+        public KafkaBridgeConfig build() {
+            Objects.requireNonNull(bootstrapServers, "bootstrapServers is required");
+            return new KafkaBridgeConfig(this);
+        }
+
+        public Builder consumerGroupId(String consumerGroupId) {
+            this.consumerGroupId = consumerGroupId;
+            return this;
+        }
+
+        public Builder dlqTopic(String dlqTopic) {
+            this.dlqTopic = dlqTopic;
+            return this;
+        }
+
+        public Builder kafkaProperties(Map<String, String> properties) {
+            kafkaProperties.putAll(properties);
+            return this;
+        }
+
+        public Builder kafkaProperty(String key, String value) {
+            kafkaProperties.put(key, value);
+            return this;
+        }
+
+        public Builder pollTimeoutMs(long pollTimeoutMs) {
+            this.pollTimeoutMs = pollTimeoutMs;
+            return this;
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private final String bootstrapServers;
+    private final String consumerGroupId;
+    private final String dlqTopic;
+
+    private final long pollTimeoutMs;
+
+    private final Map<String, String> kafkaProperties;
+
+    private KafkaBridgeConfig(Builder builder) {
+        this.bootstrapServers = builder.bootstrapServers;
+        this.consumerGroupId = builder.consumerGroupId;
+        this.dlqTopic = builder.dlqTopic;
+        this.pollTimeoutMs = builder.pollTimeoutMs;
+        this.kafkaProperties = Map.copyOf(builder.kafkaProperties);
+    }
+
+    public String bootstrapServers() {
+        return bootstrapServers;
+    }
+
+    public String consumerGroupId() {
+        return consumerGroupId;
+    }
+
+    public Map<String, Object> consumerProperties() {
+        return consumerPropertiesForGroup(consumerGroupId);
+    }
+
+    private Map<String, Object> consumerPropertiesForGroup(String groupId) {
+        var config = new HashMap<String, Object>();
+        config.put("bootstrap.servers", bootstrapServers);
+        config.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        config.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        config.put("enable.auto.commit", "false");
+        config.put("auto.offset.reset", "earliest");
+        config.put("group.id", groupId);
+        kafkaProperties.forEach(config::put);
+        return Collections.unmodifiableMap(config);
+    }
+
+    public Map<String, Object> consumerPropertiesForTopic(String kafkaTopic) {
+        var groupId = "%s-%s".formatted(consumerGroupId, kafkaTopic);
+        return consumerPropertiesForGroup(groupId);
+    }
+
+    public String dlqTopic() {
+        return dlqTopic;
+    }
+
+    public Map<String, String> kafkaProperties() {
+        return kafkaProperties;
+    }
+
+    public long pollTimeoutMs() {
+        return pollTimeoutMs;
+    }
+
+    public Map<String, Object> producerProperties() {
+        return toKafkaConfig(false);
+    }
+
+    private Map<String, Object> toKafkaConfig(boolean consumer) {
+        var config = new HashMap<String, Object>();
+        config.put("bootstrap.servers", bootstrapServers);
+        config.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        config.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+        if (consumer) {
+            config.put("group.id", consumerGroupId);
+            config.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+            config.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+            config.put("enable.auto.commit", "false");
+            config.put("auto.offset.reset", "earliest");
+        }
+        kafkaProperties.forEach(config::put);
+        return Collections.unmodifiableMap(config);
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/StompKafkaBridge.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/StompKafkaBridge.java
@@ -1,0 +1,212 @@
+package dev.vepo.stomp4j.bridge;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import javax.net.ssl.SSLContext;
+
+import dev.vepo.stomp4j.bridge.internal.BridgeMessageHandler;
+import dev.vepo.stomp4j.bridge.internal.KafkaProducerFacade;
+import dev.vepo.stomp4j.bridge.internal.KafkaRecordToStompMapper;
+import dev.vepo.stomp4j.bridge.internal.StompToKafkaRecordMapper;
+import dev.vepo.stomp4j.bridge.internal.TopicConsumerManager;
+import dev.vepo.stomp4j.commons.TransportType;
+import dev.vepo.stomp4j.server.StompServer;
+import dev.vepo.stomp4j.server.StompSession;
+import dev.vepo.stomp4j.server.SubscriptionHandler;
+import dev.vepo.stomp4j.server.auth.StompAuthenticator;
+
+public final class StompKafkaBridge implements AutoCloseable {
+    public static final class Builder {
+        private final Set<TransportChannel> channels = new HashSet<>();
+        private KafkaBridgeConfig kafkaConfig;
+        private DestinationMapper destinationMapper = DestinationMapping.prefix("/topic/");
+        private String allowedDestinationPrefix = "/topic/";
+        private StompAuthenticator authenticator;
+        private Duration heartbeat = Duration.ofSeconds(30);
+        private String serverName = "stomp4j-kafka-bridge";
+        private SSLContext sslContext;
+        private String sslKeyStorePath;
+        private String sslKeyStorePassword;
+
+        private Builder() {}
+
+        public Builder allowedDestinationPrefix(String allowedDestinationPrefix) {
+            this.allowedDestinationPrefix = allowedDestinationPrefix;
+            return this;
+        }
+
+        public Builder authenticator(StompAuthenticator authenticator) {
+            this.authenticator = authenticator;
+            return this;
+        }
+
+        public Builder channel(TransportType type, int port) {
+            channels.add(new TransportChannel(type, port));
+            return this;
+        }
+
+        public Builder destinationMapping(DestinationMapper destinationMapper) {
+            this.destinationMapper = Objects.requireNonNull(destinationMapper);
+            return this;
+        }
+
+        public Builder heartbeat(Duration heartbeat) {
+            this.heartbeat = heartbeat;
+            return this;
+        }
+
+        public Builder kafkaConfig(KafkaBridgeConfig kafkaConfig) {
+            this.kafkaConfig = kafkaConfig;
+            return this;
+        }
+
+        public Builder serverName(String serverName) {
+            this.serverName = serverName;
+            return this;
+        }
+
+        public Builder ssl(SSLContext sslContext) {
+            this.sslContext = sslContext;
+            return this;
+        }
+
+        public Builder ssl(SSLContext sslContext, String keyStorePath, String keyStorePassword) {
+            this.sslContext = sslContext;
+            this.sslKeyStorePath = keyStorePath;
+            this.sslKeyStorePassword = keyStorePassword;
+            return this;
+        }
+
+        public StompKafkaBridge start() {
+            Objects.requireNonNull(kafkaConfig, "kafkaConfig is required");
+            if (channels.isEmpty()) {
+                throw new IllegalArgumentException("At least one channel is required");
+            }
+            var bridge = new StompKafkaBridge(this);
+            bridge.start();
+            return bridge;
+        }
+    }
+
+    public record TransportChannel(TransportType type, int port) {}
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private final Set<TransportChannel> channels;
+    private final KafkaBridgeConfig kafkaConfig;
+    private final DestinationMapper destinationMapper;
+    private final String allowedDestinationPrefix;
+    private final StompAuthenticator authenticator;
+    private final Duration heartbeat;
+    private final String serverName;
+    private final SSLContext sslContext;
+    private final String sslKeyStorePath;
+    private final String sslKeyStorePassword;
+    private final CountDownLatch shutdownLatch;
+
+    private KafkaProducerFacade producer;
+    private TopicConsumerManager consumerManager;
+    private StompServer server;
+
+    private StompKafkaBridge(Builder builder) {
+        this.channels = Set.copyOf(builder.channels);
+        this.kafkaConfig = builder.kafkaConfig;
+        this.destinationMapper = builder.destinationMapper;
+        this.allowedDestinationPrefix = builder.allowedDestinationPrefix;
+        this.authenticator = builder.authenticator;
+        this.heartbeat = builder.heartbeat;
+        this.serverName = builder.serverName;
+        this.sslContext = builder.sslContext;
+        this.sslKeyStorePath = builder.sslKeyStorePath;
+        this.sslKeyStorePassword = builder.sslKeyStorePassword;
+        this.shutdownLatch = new CountDownLatch(1);
+    }
+
+    public void awaitShutdown() throws InterruptedException {
+        shutdownLatch.await();
+    }
+
+    private SubscriptionHandler bridgeSubscriptionHandler() {
+        return new SubscriptionHandler() {
+            @Override
+            public boolean accept(String topic) {
+                if (!allowedDestinationPrefix.isEmpty() && !topic.startsWith(allowedDestinationPrefix)) {
+                    return false;
+                }
+                return destinationMapper.toKafkaTopic(topic).isPresent();
+            }
+
+            @Override
+            public void onSubscribed(StompSession session, String topic) {
+                if (Objects.nonNull(consumerManager)) {
+                    consumerManager.subscribe(topic);
+                }
+            }
+
+            @Override
+            public void onUnsubscribed(StompSession session, String topic) {
+                if (Objects.nonNull(consumerManager)) {
+                    consumerManager.unsubscribe(topic);
+                }
+            }
+        };
+    }
+
+    @Override
+    public void close() {
+        if (Objects.nonNull(server)) {
+            server.close();
+            server = null;
+        }
+        if (Objects.nonNull(consumerManager)) {
+            consumerManager.close();
+            consumerManager = null;
+        }
+        if (Objects.nonNull(producer)) {
+            producer.close();
+            producer = null;
+        }
+        shutdownLatch.countDown();
+    }
+
+    private void start() {
+        producer = new KafkaProducerFacade(kafkaConfig);
+        var messageHandler = new BridgeMessageHandler(destinationMapper,
+                                                      producer,
+                                                      new StompToKafkaRecordMapper());
+        var subscriptionHandler = bridgeSubscriptionHandler();
+
+        var serverBuilder = StompServer.builder()
+                                       .serverName(serverName)
+                                       .heartbeat(heartbeat)
+                                       .handler(messageHandler)
+                                       .subscription(subscriptionHandler);
+        channels.forEach(channel -> serverBuilder.channel(channel.type(), channel.port()));
+        if (Objects.nonNull(authenticator)) {
+            serverBuilder.authenticator(authenticator);
+        }
+        if (Objects.nonNull(sslContext)) {
+            if (Objects.nonNull(sslKeyStorePath)) {
+                serverBuilder.ssl(sslContext, sslKeyStorePath, sslKeyStorePassword);
+            } else {
+                serverBuilder.ssl(sslContext);
+            }
+        }
+
+        server = serverBuilder.start();
+        consumerManager = new TopicConsumerManager(destinationMapper,
+                                                   kafkaConfig,
+                                                   server.outboundChannel(),
+                                                   new KafkaRecordToStompMapper());
+    }
+
+    public StompServer stompServer() {
+        return server;
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/BridgeMessageHandler.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/BridgeMessageHandler.java
@@ -1,0 +1,35 @@
+package dev.vepo.stomp4j.bridge.internal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import dev.vepo.stomp4j.bridge.DestinationMapper;
+import dev.vepo.stomp4j.bridge.KafkaBridgeConfig;
+import dev.vepo.stomp4j.server.MessageHandler;
+import dev.vepo.stomp4j.server.StompMessage;
+
+public final class BridgeMessageHandler implements MessageHandler {
+    private static final Logger logger = LoggerFactory.getLogger(BridgeMessageHandler.class);
+
+    private final DestinationMapper destinationMapper;
+    private final KafkaProducerFacade producer;
+    private final StompToKafkaRecordMapper recordMapper;
+
+    public BridgeMessageHandler(DestinationMapper destinationMapper,
+                                KafkaProducerFacade producer,
+                                StompToKafkaRecordMapper recordMapper) {
+        this.destinationMapper = destinationMapper;
+        this.producer = producer;
+        this.recordMapper = recordMapper;
+    }
+
+    @Override
+    public void onSend(StompMessage message) {
+        var destination = message.destination();
+        destinationMapper.toKafkaTopic(destination).ifPresentOrElse(kafkaTopic -> {
+            var record = recordMapper.toRecord(kafkaTopic, message);
+            producer.send(record);
+            logger.debug("Produced STOMP SEND from {} to Kafka topic {}", destination, kafkaTopic);
+        }, () -> logger.warn("No Kafka topic mapping for STOMP destination {}", destination));
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/CompositeDestinationMapper.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/CompositeDestinationMapper.java
@@ -1,0 +1,25 @@
+package dev.vepo.stomp4j.bridge.internal;
+
+import java.util.List;
+import java.util.Optional;
+
+import dev.vepo.stomp4j.bridge.DestinationMapper;
+
+public final class CompositeDestinationMapper implements DestinationMapper {
+    private final List<DestinationMapper> mappers;
+
+    public CompositeDestinationMapper(List<DestinationMapper> mappers) {
+        this.mappers = List.copyOf(mappers);
+    }
+
+    @Override
+    public Optional<String> toKafkaTopic(String stompDestination) {
+        for (var mapper : mappers) {
+            var topic = mapper.toKafkaTopic(stompDestination);
+            if (topic.isPresent()) {
+                return topic;
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/ExplicitDestinationMapper.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/ExplicitDestinationMapper.java
@@ -1,0 +1,19 @@
+package dev.vepo.stomp4j.bridge.internal;
+
+import java.util.Map;
+import java.util.Optional;
+
+import dev.vepo.stomp4j.bridge.DestinationMapper;
+
+public final class ExplicitDestinationMapper implements DestinationMapper {
+    private final Map<String, String> stompToKafka;
+
+    public ExplicitDestinationMapper(Map<String, String> stompToKafka) {
+        this.stompToKafka = Map.copyOf(stompToKafka);
+    }
+
+    @Override
+    public Optional<String> toKafkaTopic(String stompDestination) {
+        return Optional.ofNullable(stompToKafka.get(stompDestination));
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/KafkaProducerFacade.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/KafkaProducerFacade.java
@@ -1,0 +1,46 @@
+package dev.vepo.stomp4j.bridge.internal;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import dev.vepo.stomp4j.bridge.KafkaBridgeConfig;
+
+public final class KafkaProducerFacade implements AutoCloseable {
+    private static final Logger logger = LoggerFactory.getLogger(KafkaProducerFacade.class);
+
+    private final KafkaProducer<String, byte[]> producer;
+    private final Optional<String> dlqTopic;
+
+    public KafkaProducerFacade(KafkaBridgeConfig config) {
+        this.producer = new KafkaProducer<>(config.producerProperties());
+        this.dlqTopic = Optional.ofNullable(config.dlqTopic()).filter(topic -> !topic.isBlank());
+    }
+
+    @Override
+    public void close() {
+        producer.close();
+    }
+
+    private void forwardToDlq(String topic, ProducerRecord<String, byte[]> record, Exception exception) {
+        try {
+            producer.send(new ProducerRecord<>(topic, record.key(), record.value()));
+            logger.warn("Forwarded failed record to DLQ topic {}", topic);
+        } catch (Exception dlqException) {
+            logger.error("Failed to forward record to DLQ topic {}", topic, dlqException);
+        }
+    }
+
+    public void send(ProducerRecord<String, byte[]> record) {
+        producer.send(record, (metadata, exception) -> {
+            if (Objects.nonNull(exception)) {
+                logger.error("Failed to produce to topic {}", record.topic(), exception);
+                dlqTopic.ifPresent(topic -> forwardToDlq(topic, record, exception));
+            }
+        });
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/KafkaRecordToStompMapper.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/KafkaRecordToStompMapper.java
@@ -1,0 +1,40 @@
+package dev.vepo.stomp4j.bridge.internal;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import dev.vepo.stomp4j.commons.protocol.Command;
+import dev.vepo.stomp4j.commons.protocol.Header;
+import dev.vepo.stomp4j.commons.protocol.Message;
+import dev.vepo.stomp4j.commons.protocol.MessageBuilder;
+
+public final class KafkaRecordToStompMapper {
+
+    private boolean hasContentType(ConsumerRecord<String, byte[]> record) {
+        for (var header : record.headers()) {
+            if ("content-type".equals(header.key())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public Message toStompMessage(String stompDestination, ConsumerRecord<String, byte[]> record) {
+        var body = new String(record.value(), StandardCharsets.UTF_8);
+        var builder = MessageBuilder.builder(Command.SEND)
+                                    .header(Header.DESTINATION, stompDestination)
+                                    .body(body);
+        record.headers().forEach(header -> {
+            var name = header.key();
+            var value = new String(header.value(), StandardCharsets.UTF_8);
+            if ("content-type".equals(name)) {
+                builder.header(Header.CONTENT_TYPE, value);
+            }
+        });
+        if (!hasContentType(record)) {
+            builder.header(Header.CONTENT_TYPE, "text/plain");
+        }
+        return builder.build();
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/PrefixDestinationMapper.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/PrefixDestinationMapper.java
@@ -1,0 +1,28 @@
+package dev.vepo.stomp4j.bridge.internal;
+
+import java.util.Optional;
+
+import dev.vepo.stomp4j.bridge.DestinationMapper;
+
+public final class PrefixDestinationMapper implements DestinationMapper {
+    private final String prefix;
+
+    public PrefixDestinationMapper(String prefix) {
+        if (prefix.isEmpty()) {
+            throw new IllegalArgumentException("prefix cannot be empty");
+        }
+        this.prefix = prefix;
+    }
+
+    @Override
+    public Optional<String> toKafkaTopic(String stompDestination) {
+        if (!stompDestination.startsWith(prefix)) {
+            return Optional.empty();
+        }
+        var remainder = stompDestination.substring(prefix.length());
+        if (remainder.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(remainder.replace('/', '.'));
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/StompToKafkaRecordMapper.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/StompToKafkaRecordMapper.java
@@ -1,0 +1,40 @@
+package dev.vepo.stomp4j.bridge.internal;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+
+import dev.vepo.stomp4j.commons.protocol.Header;
+import dev.vepo.stomp4j.server.StompMessage;
+
+public final class StompToKafkaRecordMapper {
+    private static final String KAFKA_KEY_HEADER = "kafka-key";
+
+    private List<RecordHeader> mapHeaders(StompMessage message) {
+        var headers = new ArrayList<RecordHeader>();
+        message.headers().get(Header.CONTENT_TYPE).ifPresent(value -> headers.add(toHeader("content-type", value)));
+        return headers;
+    }
+
+    private Optional<String> resolveKey(StompMessage message) {
+        return message.headers().get(KAFKA_KEY_HEADER);
+    }
+
+    private RecordHeader toHeader(String name, String value) {
+        return new RecordHeader(name, value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public ProducerRecord<String, byte[]> toRecord(String kafkaTopic, StompMessage message) {
+        var body = Objects.requireNonNullElse(message.body(), "");
+        var bytes = body.getBytes(StandardCharsets.UTF_8);
+        var key = resolveKey(message).orElse(null);
+        var record = new ProducerRecord<>(kafkaTopic, key, bytes);
+        mapHeaders(message).forEach(header -> record.headers().add(header));
+        return record;
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/TopicConsumerManager.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/dev/vepo/stomp4j/bridge/internal/TopicConsumerManager.java
@@ -1,0 +1,165 @@
+package dev.vepo.stomp4j.bridge.internal;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.WakeupException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import dev.vepo.stomp4j.bridge.DestinationMapper;
+import dev.vepo.stomp4j.bridge.KafkaBridgeConfig;
+import dev.vepo.stomp4j.server.OutboundChannel;
+
+public final class TopicConsumerManager implements AutoCloseable {
+    private static final class DestinationConsumer {
+        private static void pollLoop(KafkaBridgeConfig config,
+                                     OutboundChannel outboundChannel,
+                                     KafkaRecordToStompMapper recordMapper,
+                                     String stompDestination,
+                                     KafkaConsumer<String, byte[]> consumer,
+                                     AtomicBoolean running) {
+            while (running.get()) {
+                try {
+                    var records = consumer.poll(java.time.Duration.ofMillis(config.pollTimeoutMs()));
+                    for (var record : records) {
+                        var message = recordMapper.toStompMessage(stompDestination, record);
+                        outboundChannel.send(message);
+                        consumer.commitSync();
+                    }
+                } catch (WakeupException ex) {
+                    if (running.get()) {
+                        logger.warn("Kafka consumer wakeup for destination {}", stompDestination, ex);
+                    }
+                } catch (Exception ex) {
+                    logger.error("Kafka consumer error for destination {}", stompDestination, ex);
+                }
+            }
+        }
+
+        static DestinationConsumer start(ExecutorService executor,
+                                         KafkaBridgeConfig config,
+                                         OutboundChannel outboundChannel,
+                                         KafkaRecordToStompMapper recordMapper,
+                                         String stompDestination,
+                                         String kafkaTopic) {
+            var kafkaConsumer = new KafkaConsumer<String, byte[]>(config.consumerPropertiesForTopic(kafkaTopic));
+            kafkaConsumer.subscribe(List.of(kafkaTopic));
+            var subscribers = new AtomicInteger(1);
+            var running = new AtomicBoolean(true);
+            var pollTask = executor.submit(() -> pollLoop(config,
+                                                          outboundChannel,
+                                                          recordMapper,
+                                                          stompDestination,
+                                                          kafkaConsumer,
+                                                          running));
+            return new DestinationConsumer(subscribers, kafkaConsumer, running, pollTask);
+        }
+
+        private final AtomicInteger subscribers;
+        private final KafkaConsumer<String, byte[]> consumer;
+
+        private final AtomicBoolean running;
+
+        private final Future<?> task;
+
+        private DestinationConsumer(AtomicInteger subscribers,
+                                    KafkaConsumer<String, byte[]> consumer,
+                                    AtomicBoolean running,
+                                    Future<?> task) {
+            this.subscribers = subscribers;
+            this.consumer = consumer;
+            this.running = running;
+            this.task = task;
+        }
+
+        int decrement() {
+            return subscribers.decrementAndGet();
+        }
+
+        int increment() {
+            return subscribers.incrementAndGet();
+        }
+
+        void stop() {
+            running.set(false);
+            consumer.wakeup();
+            try {
+                task.get();
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            } catch (Exception ex) {
+                logger.debug("Consumer task ended", ex);
+            }
+            consumer.close();
+        }
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(TopicConsumerManager.class);
+    private final DestinationMapper destinationMapper;
+    private final KafkaBridgeConfig config;
+    private final OutboundChannel outboundChannel;
+    private final KafkaRecordToStompMapper recordMapper;
+    private final ExecutorService executor;
+
+    private final ConcurrentMap<String, DestinationConsumer> consumers;
+
+    public TopicConsumerManager(DestinationMapper destinationMapper,
+                                KafkaBridgeConfig config,
+                                OutboundChannel outboundChannel,
+                                KafkaRecordToStompMapper recordMapper) {
+        this.destinationMapper = destinationMapper;
+        this.config = config;
+        this.outboundChannel = outboundChannel;
+        this.recordMapper = recordMapper;
+        this.executor = Executors.newCachedThreadPool(r -> {
+            var thread = new Thread(r, "stomp4j-kafka-bridge-consumer");
+            thread.setDaemon(true);
+            return thread;
+        });
+        this.consumers = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void close() {
+        consumers.values().forEach(DestinationConsumer::stop);
+        consumers.clear();
+        executor.shutdownNow();
+    }
+
+    public void subscribe(String stompDestination) {
+        destinationMapper.toKafkaTopic(stompDestination).ifPresentOrElse(kafkaTopic -> consumers.compute(stompDestination,
+                                                                                                         (destination, existing) -> {
+                                                                                                             if (Objects.isNull(existing)) {
+                                                                                                                 return DestinationConsumer.start(executor,
+                                                                                                                                                  config,
+                                                                                                                                                  outboundChannel,
+                                                                                                                                                  recordMapper,
+                                                                                                                                                  destination,
+                                                                                                                                                  kafkaTopic);
+                                                                                                             }
+                                                                                                             existing.increment();
+                                                                                                             return existing;
+                                                                                                         }),
+                                                                         () -> logger.warn("Cannot subscribe to unmapped destination {}",
+                                                                                           stompDestination));
+    }
+
+    public void unsubscribe(String stompDestination) {
+        consumers.computeIfPresent(stompDestination, (destination, consumer) -> {
+            if (consumer.decrement() <= 0) {
+                consumer.stop();
+                return null;
+            }
+            return consumer;
+        });
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/main/java/module-info.java
+++ b/bridge/stomp4j-kafka-bridge/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module stomp4j.kafka.bridge {
+    requires transitive stomp4j.server;
+    requires kafka.clients;
+    requires org.slf4j;
+
+    exports dev.vepo.stomp4j.bridge;
+}

--- a/bridge/stomp4j-kafka-bridge/src/test/java/dev/vepo/stomp4j/bridge/tests/DestinationMapperTest.java
+++ b/bridge/stomp4j-kafka-bridge/src/test/java/dev/vepo/stomp4j/bridge/tests/DestinationMapperTest.java
@@ -1,0 +1,34 @@
+package dev.vepo.stomp4j.bridge.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import dev.vepo.stomp4j.bridge.DestinationMapping;
+
+class DestinationMapperTest {
+
+    @Test
+    @DisplayName("Explicit mapper should override prefix mapping")
+    void explicitMapperShouldOverridePrefix() {
+        var mapper = DestinationMapping.composite(DestinationMapping.explicit(Map.of("/topic/legacy", "legacy-topic")),
+                                                  DestinationMapping.prefix("/topic/"));
+
+        assertThat(mapper.toKafkaTopic("/topic/legacy")).contains("legacy-topic");
+        assertThat(mapper.toKafkaTopic("/topic/orders")).contains("orders");
+    }
+
+    @Test
+    @DisplayName("Prefix mapper should strip topic prefix and replace slashes")
+    void prefixMapperShouldMapDestinationToTopic() {
+        var mapper = DestinationMapping.prefix("/topic/");
+
+        assertThat(mapper.toKafkaTopic("/topic/orders")).contains("orders");
+        assertThat(mapper.toKafkaTopic("/topic/chat/lobby")).contains("chat.lobby");
+        assertThat(mapper.toKafkaTopic("/queue/orders")).isEmpty();
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/test/java/dev/vepo/stomp4j/bridge/tests/StompKafkaBridgeIntegrationTest.java
+++ b/bridge/stomp4j-kafka-bridge/src/test/java/dev/vepo/stomp4j/bridge/tests/StompKafkaBridgeIntegrationTest.java
@@ -1,0 +1,196 @@
+package dev.vepo.stomp4j.bridge.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import dev.vepo.stomp4j.bridge.DestinationMapping;
+import dev.vepo.stomp4j.bridge.KafkaBridgeConfig;
+import dev.vepo.stomp4j.bridge.StompKafkaBridge;
+import dev.vepo.stomp4j.bridge.tests.infra.KafkaTestExtension;
+import dev.vepo.stomp4j.client.StompClient;
+import dev.vepo.stomp4j.client.UserCredential;
+import dev.vepo.stomp4j.client.exceptions.StompException;
+import dev.vepo.stomp4j.commons.TransportType;
+
+@ExtendWith(KafkaTestExtension.class)
+class StompKafkaBridgeIntegrationTest {
+
+    @Test
+    @DisplayName("Bridge should reject STOMP authentication when configured")
+    @Timeout(120)
+    void bridgeShouldRejectInvalidCredentials() throws InterruptedException {
+        var tcpPort = randomPort();
+
+        try (var bridge = StompKafkaBridge.builder()
+                                          .kafkaConfig(kafkaConfig())
+                                          .destinationMapping(DestinationMapping.prefix("/topic/"))
+                                          .channel(TransportType.TCP, tcpPort)
+                                          .authenticator(credentials -> "bridge".equals(credentials.username())
+                                                  && "secret".equals(credentials.password()))
+                                          .start();
+                var client = StompClient.create("stomp://localhost:%d".formatted(tcpPort), new UserCredential("wrong", "creds"))) {
+            assertThatThrownBy(client::connect).isInstanceOf(StompException.class);
+        }
+    }
+
+    private KafkaBridgeConfig kafkaConfig() {
+        return KafkaBridgeConfig.builder()
+                                .bootstrapServers(KafkaTestExtension.kafka().bootstrapServers())
+                                .consumerGroupId("stomp4j-bridge-test-%s".formatted(UUID.randomUUID()))
+                                .pollTimeoutMs(500L)
+                                .build();
+    }
+
+    private KafkaConsumer<String, byte[]> kafkaConsumer(String topic) {
+        var properties = new Properties();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaTestExtension.kafka().bootstrapServers());
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "stomp4j-bridge-verify-" + UUID.randomUUID());
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        var consumer = new KafkaConsumer<String, byte[]>(properties);
+        consumer.subscribe(List.of(topic));
+        return consumer;
+    }
+
+    private KafkaProducer<String, byte[]> kafkaProducer() {
+        var properties = new Properties();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaTestExtension.kafka().bootstrapServers());
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        return new KafkaProducer<>(properties);
+    }
+
+    @Test
+    @DisplayName("Kafka record should be delivered to STOMP subscriber")
+    @Timeout(120)
+    void kafkaRecordShouldBeDeliveredToStompSubscriber() throws Exception {
+        var tcpPort = randomPort();
+        var topic = "events-" + UUID.randomUUID();
+        var stompDestination = "/topic/" + topic;
+
+        try (var bridge = startBridge(tcpPort);
+                var stompClient = StompClient.create("stomp://localhost:%d".formatted(tcpPort))) {
+            stompClient.connect();
+            var subscription = stompClient.subscribe(stompDestination);
+            await().atMost(Duration.ofSeconds(10)).pollDelay(Duration.ofMillis(500)).until(() -> true);
+
+            try (var producer = kafkaProducer()) {
+                producer.send(new ProducerRecord<>(topic, "event-1".getBytes(StandardCharsets.UTF_8))).get();
+            }
+
+            await().atMost(Duration.ofSeconds(30)).until(subscription::hasData);
+            assertThat(subscription.poll()).containsExactly("event-1");
+        }
+    }
+
+    @Test
+    @DisplayName("Multiple STOMP subscribers should receive Kafka broadcast")
+    @Timeout(120)
+    void multipleSubscribersShouldReceiveBroadcast() throws Exception {
+        var tcpPort = randomPort();
+        var topic = "fanout-" + UUID.randomUUID();
+        var stompDestination = "/topic/" + topic;
+
+        try (var bridge = startBridge(tcpPort);
+                var clientOne = StompClient.create("stomp://localhost:%d".formatted(tcpPort));
+                var clientTwo = StompClient.create("stomp://localhost:%d".formatted(tcpPort))) {
+            clientOne.connect();
+            clientTwo.connect();
+            var subscriptionOne = clientOne.subscribe(stompDestination);
+            var subscriptionTwo = clientTwo.subscribe(stompDestination);
+            await().atMost(Duration.ofSeconds(10)).pollDelay(Duration.ofMillis(500)).until(() -> true);
+
+            try (var producer = kafkaProducer()) {
+                producer.send(new ProducerRecord<>(topic, "broadcast".getBytes(StandardCharsets.UTF_8))).get();
+            }
+
+            await().atMost(Duration.ofSeconds(30)).until(() -> subscriptionOne.hasData() && subscriptionTwo.hasData());
+            assertThat(subscriptionOne.poll()).containsExactly("broadcast");
+            assertThat(subscriptionTwo.poll()).containsExactly("broadcast");
+        }
+    }
+
+    private int randomPort() {
+        return 16000 + (int) (Math.random() * 2000);
+    }
+
+    private StompKafkaBridge startBridge(int tcpPort) {
+        return StompKafkaBridge.builder()
+                               .kafkaConfig(kafkaConfig())
+                               .destinationMapping(DestinationMapping.prefix("/topic/"))
+                               .channel(TransportType.TCP, tcpPort)
+                               .start();
+    }
+
+    @Test
+    @DisplayName("STOMP SEND should produce to Kafka topic")
+    @Timeout(120)
+    void stompSendShouldProduceToKafka() throws Exception {
+        var tcpPort = randomPort();
+        var topic = "orders-" + UUID.randomUUID();
+        var stompDestination = "/topic/" + topic;
+
+        try (var bridge = startBridge(tcpPort);
+                var stompClient = StompClient.create("stomp://localhost:%d".formatted(tcpPort))) {
+            stompClient.connect();
+            stompClient.sendPlain(stompDestination, "order-1", "text/plain");
+
+            try (var consumer = kafkaConsumer(topic)) {
+                await().atMost(Duration.ofSeconds(30)).until(() -> {
+                    var records = consumer.poll(Duration.ofMillis(500));
+                    if (records.isEmpty()) {
+                        return false;
+                    }
+                    var record = records.iterator().next();
+                    assertThat(new String(record.value(), StandardCharsets.UTF_8)).isEqualTo("order-1");
+                    return true;
+                });
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Unsubscribe should stop Kafka to STOMP delivery")
+    @Timeout(120)
+    void unsubscribeShouldStopDelivery() throws Exception {
+        var tcpPort = randomPort();
+        var topic = "unsub-" + UUID.randomUUID();
+        var stompDestination = "/topic/" + topic;
+
+        try (var bridge = startBridge(tcpPort);
+                var stompClient = StompClient.create("stomp://localhost:%d".formatted(tcpPort))) {
+            stompClient.connect();
+            var subscription = stompClient.subscribe(stompDestination);
+            stompClient.unsubscribe(subscription);
+
+            try (var producer = kafkaProducer()) {
+                producer.send(new ProducerRecord<>(topic, "after-unsub".getBytes(StandardCharsets.UTF_8))).get();
+            }
+
+            await().pollDelay(Duration.ofSeconds(2)).until(() -> true);
+            assertThat(subscription.hasData()).isFalse();
+        }
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/test/java/dev/vepo/stomp4j/bridge/tests/infra/KafkaTestContainer.java
+++ b/bridge/stomp4j-kafka-bridge/src/test/java/dev/vepo/stomp4j/bridge/tests/infra/KafkaTestContainer.java
@@ -1,0 +1,33 @@
+package dev.vepo.stomp4j.bridge.tests.infra;
+
+import java.time.Duration;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+public final class KafkaTestContainer extends GenericContainer<KafkaTestContainer> {
+    private static final int KAFKA_PORT = 9092;
+    private static final DockerImageName IMAGE = DockerImageName.parse("apache/kafka-native:3.8.0");
+
+    public KafkaTestContainer() {
+        super(IMAGE);
+        withEnv("KAFKA_NODE_ID", "1");
+        withEnv("KAFKA_PROCESS_ROLES", "broker,controller");
+        withEnv("KAFKA_LISTENERS", "PLAINTEXT://0.0.0.0:%d,CONTROLLER://0.0.0.0:9093".formatted(KAFKA_PORT));
+        withEnv("KAFKA_ADVERTISED_LISTENERS", "PLAINTEXT://localhost:%d".formatted(KAFKA_PORT));
+        withEnv("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER");
+        withEnv("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT");
+        withEnv("KAFKA_CONTROLLER_QUORUM_VOTERS", "1@localhost:9093");
+        withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1");
+        withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1");
+        withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1");
+        withEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0");
+        addFixedExposedPort(KAFKA_PORT, KAFKA_PORT);
+        waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(2)));
+    }
+
+    public String bootstrapServers() {
+        return "localhost:%d".formatted(KAFKA_PORT);
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/test/java/dev/vepo/stomp4j/bridge/tests/infra/KafkaTestExtension.java
+++ b/bridge/stomp4j-kafka-bridge/src/test/java/dev/vepo/stomp4j/bridge/tests/infra/KafkaTestExtension.java
@@ -1,0 +1,25 @@
+package dev.vepo.stomp4j.bridge.tests.infra;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public final class KafkaTestExtension implements BeforeAllCallback, AfterAllCallback {
+    private static final KafkaTestContainer KAFKA = new KafkaTestContainer();
+
+    public static KafkaTestContainer kafka() {
+        return KAFKA;
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        KAFKA.stop();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        if (!KAFKA.isRunning()) {
+            KAFKA.start();
+        }
+    }
+}

--- a/bridge/stomp4j-kafka-bridge/src/test/java/module-info.java
+++ b/bridge/stomp4j-kafka-bridge/src/test/java/module-info.java
@@ -1,0 +1,12 @@
+module stomp4j.kafka.bridge.test {
+    requires stomp4j.kafka.bridge;
+    requires stomp4j.client;
+    requires org.junit.jupiter.api;
+    requires org.assertj.core;
+    requires awaitility;
+    requires kafka.clients;
+    requires testcontainers;
+
+    opens dev.vepo.stomp4j.bridge.tests to org.junit.platform.commons;
+    opens dev.vepo.stomp4j.bridge.tests.infra to org.junit.platform.commons;
+}

--- a/bridge/stomp4j-kafka-bridge/src/test/resources/logback.xml
+++ b/bridge/stomp4j-kafka-bridge/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<logback>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</logback>

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,11 @@ User-facing guides for library consumers. Maintainer references live at the repo
 1. [quarkus-guide.md](quarkus-guide.md) — extensions, CDI Events, `@StompDestination`
 2. [samples/README.md](../samples/README.md) — Quarkus client/server samples (ports 8083/8084)
 
+### I need STOMP ↔ Kafka bridging
+
+1. [kafka-bridge-guide.md](kafka-bridge-guide.md) — library API, JAR, Docker
+2. [samples/docker-compose.yaml](../samples/docker-compose.yaml) — `kafka` + `stomp-kafka-bridge` services
+
 ### I am extending or integrating deeply
 
 1. [advanced-topics.md](advanced-topics.md) — SPI, JPMS modules, wire format, heart-beats
@@ -42,5 +47,6 @@ User-facing guides for library consumers. Maintainer references live at the repo
 | [client-guide.md](client-guide.md) | Intermediate | URLs, subscriptions, send, close lifecycle |
 | [spring-guide.md](spring-guide.md) | Intermediate | Spring Boot starters, `@StompListener`, templates |
 | [quarkus-guide.md](quarkus-guide.md) | Intermediate | Quarkus extensions, CDI Events, inbound `@Observes` |
+| [kafka-bridge-guide.md](kafka-bridge-guide.md) | Intermediate | STOMP ↔ Kafka bridge, mapping, deployment |
 | [advanced-topics.md](advanced-topics.md) | Advanced | Versions, SPI, TLS, commons protocol API |
 | [domain-specification.md](domain-specification.md) | Contributors | Ubiquitous language, protocol invariants |

--- a/docs/domain-specification.md
+++ b/docs/domain-specification.md
@@ -28,7 +28,7 @@ STOMP protocol vocabulary and library-specific terms. Agents must align code and
 | **StompMessage** | Inbound client `SEND` delivered to `MessageHandler` with destination, body, headers, and session channel |
 | **StompSession** | Read-only view of a connected client (`login`, negotiated `version`, `outboundChannel`) |
 | **MessageHandler** | Callback invoked when a client `SEND`s to a destination (`onSend(StompMessage)`) |
-| **SubscriptionHandler** | Predicate deciding whether a session may `SUBSCRIBE` to a destination |
+| **SubscriptionHandler** | Predicate deciding whether a session may `SUBSCRIBE` to a destination; optional `onSubscribed` / `onUnsubscribed` lifecycle callbacks |
 | **StompAuthenticator** | Callback validating credentials on `CONNECT` |
 | **Protocol version** | `1.0`, `1.1`, or `1.2` — negotiated from `accept-version` on `CONNECT` |
 
@@ -60,6 +60,15 @@ STOMP protocol vocabulary and library-specific terms. Agents must align code and
 | **Acknowledgment** | Spring-facing manual ack/nack for `@StompListener` methods |
 | **StompClientTemplate** | High-level client send API with lifecycle managed by Spring |
 | **StompOutboundTemplate** | Embedded server outbound push with optional subscriber ACK callbacks |
+
+### Kafka bridge (optional)
+
+| Term | Meaning |
+|------|---------|
+| **Bridge** | `StompKafkaBridge` process routing STOMP traffic to Kafka and back |
+| **Destination mapping** | Rule translating a STOMP `destination` to a Kafka topic name |
+| **Topic consumer** | Kafka consumer started when the first client subscribes to a destination; stopped when the last unsubscribes |
+| **Prefix mapping** | Strip a STOMP prefix (for example `/topic/`) and map `/` to `.` in the Kafka topic |
 
 ## Invariants
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,7 +11,7 @@ When you add, change, or remove user-visible behaviour, **update this page** in 
 | **Client** | TCP & WebSocket, TLS, STOMP 1.0–1.2, subscribe/send, callback & polling |
 | **Server** | Embeddable TCP & WebSocket, handlers, auth, outbound push, TLS |
 | **Commons** | Frame encode/decode, headers, commands |
-| **Platform** | Java 21, JPMS modules, SLF4J, optional Spring Boot starters, optional Quarkus extensions |
+| **Platform** | Java 21, JPMS modules, SLF4J, optional Spring Boot starters, optional Quarkus extensions, Kafka bridge |
 
 ## Client (`stomp4j-client`)
 
@@ -56,6 +56,7 @@ When you add, change, or remove user-visible behaviour, **update this page** in 
 | Subscriber ACK/NACK callbacks | Supported | `AcknowledgedOutboundChannel.send(..., SubscriberAckListener)` |
 | Per-session reply | Supported | `StompMessage.sessionChannel()` |
 | Connection lifecycle hooks | Supported | `StompConnectionListener` |
+| Subscription lifecycle hooks | Supported | `SubscriptionHandler.onSubscribed` / `onUnsubscribed` |
 | Heart-beat negotiation | Supported | `.heartbeat(Duration)` on builder |
 | Configurable server name | Supported | `.serverName(...)` on `CONNECTED` |
 | STOMP transactions (`BEGIN` / `COMMIT` / `ABORT`) | Not supported | — |
@@ -97,6 +98,26 @@ When you add, change, or remove user-visible behaviour, **update this page** in 
 | `DISCONNECT` | On `close()` | Session teardown |
 | `BEGIN` / `COMMIT` / `ABORT` | — | Not supported |
 
+## Kafka bridge (`stomp4j-kafka-bridge`)
+
+| Feature | Status | Details |
+|---------|--------|---------|
+| Embeddable bridge API | Supported | `StompKafkaBridge.builder()` — [kafka-bridge-guide.md](kafka-bridge-guide.md) |
+| Runnable fat JAR | Supported | `stomp4j-kafka-bridge-runner` |
+| Docker image / Compose | Supported | `samples/kafka-bridge-sample`, `samples/docker-compose.yaml` |
+| STOMP `SEND` → Kafka produce | Supported | Prefix and explicit destination mapping |
+| Kafka consume → STOMP `MESSAGE` | Supported | Refcounted consumer per destination |
+| Multi-subscriber fan-out | Supported | Broadcast via `OutboundChannel` |
+| STOMP TLS / auth | Supported | Reuses `StompServer` builder |
+| Kafka SASL / SSL | Supported | `bridge.kafka.property.*` / env pass-through |
+| Optional DLQ on produce failure | Supported | `bridge.dlq.topic` |
+| Client-ack ↔ Kafka offset | Not supported | `auto` ack only |
+| `/queue/` competing consumers | Not supported | Topic broadcast semantics only |
+| STOMP transactions | Not supported | — |
+| Multi-bridge replica coordination | Not supported | — |
+| Schema Registry / Avro | Not supported | — |
+| Spring Boot / Quarkus auto-config | Not supported | Use library or runner |
+
 Normative behaviour: [STOMP specification](https://stomp.github.io/). Library terms: [domain-specification.md](domain-specification.md).
 
 ## Where to go next
@@ -108,5 +129,6 @@ Normative behaviour: [STOMP specification](https://stomp.github.io/). Library te
 | Spring Boot integration | [spring-guide.md](spring-guide.md) |
 | Quarkus integration | [quarkus-guide.md](quarkus-guide.md) |
 | Embedded server patterns | [server-guide.md](server-guide.md) |
+| STOMP ↔ Kafka bridge | [kafka-bridge-guide.md](kafka-bridge-guide.md) |
 | SPI, TLS, wire format | [advanced-topics.md](advanced-topics.md) |
 | Design philosophy | [overview.md](overview.md) |

--- a/docs/kafka-bridge-guide.md
+++ b/docs/kafka-bridge-guide.md
@@ -1,0 +1,107 @@
+# Kafka bridge guide
+
+Bidirectional routing between STOMP clients and Apache Kafka topics using `stomp4j-kafka-bridge`.
+
+## Artifacts
+
+| Artifact | Use |
+|----------|-----|
+| `stomp4j-kafka-bridge` | Embeddable library API |
+| `stomp4j-kafka-bridge-runner` | Executable fat JAR (`java -jar`) |
+| `samples/kafka-bridge-sample` | Docker image build |
+
+Maven coordinates (build from source while on `1.1.1-SNAPSHOT`):
+
+```xml
+<dependency>
+    <groupId>dev.vepo</groupId>
+    <artifactId>stomp4j-kafka-bridge</artifactId>
+    <version>1.1.1-SNAPSHOT</version>
+</dependency>
+```
+
+## Library API
+
+```java
+try (var bridge = StompKafkaBridge.builder()
+        .kafkaConfig(KafkaBridgeConfig.builder()
+                .bootstrapServers("localhost:9092")
+                .build())
+        .destinationMapping(DestinationMapping.prefix("/topic/"))
+        .allowedDestinationPrefix("/topic/")
+        .channel(TransportType.TCP, 61613)
+        .channel(TransportType.WEB_SOCKET, 61614)
+        .start()) {
+
+  bridge.awaitShutdown();
+}
+```
+
+### Destination mapping
+
+Default prefix mapping:
+
+| STOMP destination | Kafka topic |
+|-------------------|-------------|
+| `/topic/orders` | `orders` |
+| `/topic/chat/lobby` | `chat.lobby` |
+
+Explicit overrides:
+
+```java
+DestinationMapping.composite(
+    DestinationMapping.explicit(Map.of("/topic/legacy", "legacy-topic")),
+    DestinationMapping.prefix("/topic/"));
+```
+
+### STOMP → Kafka
+
+Inbound `SEND` frames are published to the mapped Kafka topic. Optional record key via STOMP header `kafka-key`.
+
+### Kafka → STOMP
+
+When a client `SUBSCRIBE`s, the bridge starts a Kafka consumer for the mapped topic (refcounted per destination) and delivers records as STOMP `MESSAGE` frames to all subscribers on that destination.
+
+## Runnable JAR
+
+```bash
+export KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+java -jar stomp4j-kafka-bridge-runner.jar
+```
+
+Configuration precedence: environment variables, then `application.properties` on the classpath.
+
+| Variable / property | Default | Purpose |
+|---------------------|---------|---------|
+| `KAFKA_BOOTSTRAP_SERVERS` / `bridge.kafka.bootstrap-servers` | — | Required |
+| `STOMP_TCP_PORT` / `bridge.stomp.tcp-port` | `61613` | STOMP TCP port |
+| `STOMP_WS_PORT` / `bridge.stomp.ws-port` | `61614` | STOMP WebSocket port |
+| `DESTINATION_PREFIX` / `bridge.destination.prefix` | `/topic/` | Allowed subscription prefix |
+| `TOPIC_PREFIX_STRIP` / `bridge.topic.prefix-strip` | `/topic/` | Mapping input prefix |
+| `KAFKA_CONSUMER_GROUP_ID` / `bridge.kafka.consumer-group-id` | `stomp4j-bridge` | Base consumer group |
+| `STOMP_AUTH_USERNAME` / `bridge.stomp.auth.username` | — | Optional CONNECT login |
+| `STOMP_AUTH_PASSWORD` / `bridge.stomp.auth.password` | — | Optional CONNECT passcode |
+| `BRIDGE_DLQ_TOPIC` / `bridge.dlq.topic` | — | Optional DLQ for failed produces |
+| `bridge.mapping.<stomp-destination>` | — | Explicit STOMP → Kafka map |
+| `bridge.kafka.property.<key>` | — | Pass-through to `kafka-clients` |
+
+Kafka SASL/SSL: set standard `bridge.kafka.property.*` entries (for example `bridge.kafka.property.security.protocol=SASL_SSL`).
+
+## Docker
+
+From the repository root:
+
+```bash
+docker compose -f samples/docker-compose.yaml up kafka stomp-kafka-bridge
+```
+
+Connect STOMP clients to `stomp://localhost:61613` or `ws://localhost:61614/`.
+
+## Limitations
+
+- STOMP `auto` ack only (offset committed after outbound delivery)
+- Broadcast topic semantics only (not `/queue/` competing consumers)
+- No STOMP transactions (`BEGIN` / `COMMIT` / `ABORT`)
+- Single bridge instance per consumer group (no multi-replica coordination)
+
+See [features.md#kafka-bridge-stomp4j-kafka-bridge](features.md#kafka-bridge-stomp4j-kafka-bridge) for the capability checklist.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,8 +22,13 @@ Stomp4J is a Maven multi-module project. Published artifacts on Maven Central us
 stomp4j-parent
 ├── stomp4j-commons   (wire format — frames, headers, commands)
 ├── stomp4j-client    → commons   (StompClient, transports, protocol versions)
-└── stomp4j-server    → commons   (StompServer, handlers; Vert.x for WebSocket)
+├── stomp4j-server    → commons   (StompServer, handlers; Vert.x for WebSocket)
+└── stomp4j-bridge    → server    (StompKafkaBridge — optional Kafka integration)
 ```
+
+### stomp4j-kafka-bridge (optional)
+
+Bidirectional STOMP ↔ Kafka routing. Artifacts: `stomp4j-kafka-bridge` (library), `stomp4j-kafka-bridge-runner` (fat JAR). See [kafka-bridge-guide.md](kafka-bridge-guide.md).
 
 ### stomp4j-commons
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,11 @@
                 <version>4.3.0</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>3.9.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -335,11 +340,13 @@
         <module>server</module>
         <module>spring</module>
         <module>quarkus</module>
+        <module>bridge</module>
         <module>samples/spring-client-sample</module>
         <module>samples/spring-server-sample</module>
         <module>samples/plain-client-sample</module>
         <module>samples/plain-server-sample</module>
         <module>samples/quarkus-client-sample</module>
         <module>samples/quarkus-server-sample</module>
+        <module>samples/kafka-bridge-sample</module>
     </modules>
 </project>

--- a/samples/docker-compose.yaml
+++ b/samples/docker-compose.yaml
@@ -78,3 +78,37 @@ services:
       - "8084:8084"
       - "5520:5520"
       - "5521:5521"
+
+  kafka:
+    image: apache/kafka:3.8.0
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: "1"
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
+
+  stomp-kafka-bridge:
+    build:
+      context: ..
+      dockerfile: samples/kafka-bridge-sample/Dockerfile
+    depends_on:
+      - kafka
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      STOMP_TCP_PORT: "61613"
+      STOMP_WS_PORT: "61614"
+      DESTINATION_PREFIX: /topic/
+      TOPIC_PREFIX_STRIP: /topic/
+      KAFKA_CONSUMER_GROUP_ID: stomp4j-bridge
+    ports:
+      - "61613:61613"
+      - "61614:61614"

--- a/samples/kafka-bridge-sample/Dockerfile
+++ b/samples/kafka-bridge-sample/Dockerfile
@@ -1,0 +1,9 @@
+FROM maven:3.9-eclipse-temurin-21 AS build
+WORKDIR /workspace
+COPY . .
+RUN mvn -pl bridge/stomp4j-kafka-bridge-runner -am package -DskipTests
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/bridge/stomp4j-kafka-bridge-runner/target/stomp4j-kafka-bridge-runner-*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/samples/kafka-bridge-sample/pom.xml
+++ b/samples/kafka-bridge-sample/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.vepo</groupId>
+        <artifactId>stomp4j-parent</artifactId>
+        <version>1.1.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>kafka-bridge-sample</artifactId>
+    <name>Stomp4J :: Kafka Bridge Sample</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.vepo</groupId>
+            <artifactId>stomp4j-kafka-bridge-runner</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/server/src/main/java/dev/vepo/stomp4j/server/StompServer.java
+++ b/server/src/main/java/dev/vepo/stomp4j/server/StompServer.java
@@ -147,6 +147,16 @@ public class StompServer implements AutoCloseable {
         }
 
         @Override
+        public void subscriptionEstablished(Session session, String topic) {
+            subscriptionHandler.onSubscribed(session, topic);
+        }
+
+        @Override
+        public void subscriptionRemoved(Session session, String topic) {
+            subscriptionHandler.onUnsubscribed(session, topic);
+        }
+
+        @Override
         public boolean subscriptionRequested(Session session, String topic) {
             return subscriptionHandler.accept(topic);
         }

--- a/server/src/main/java/dev/vepo/stomp4j/server/SubscriptionHandler.java
+++ b/server/src/main/java/dev/vepo/stomp4j/server/SubscriptionHandler.java
@@ -4,4 +4,7 @@ public interface SubscriptionHandler {
 
     boolean accept(String topic);
 
+    default void onSubscribed(StompSession session, String topic) {}
+
+    default void onUnsubscribed(StompSession session, String topic) {}
 }

--- a/server/src/main/java/dev/vepo/stomp4j/server/channels/ChannelListener.java
+++ b/server/src/main/java/dev/vepo/stomp4j/server/channels/ChannelListener.java
@@ -11,5 +11,9 @@ public interface ChannelListener {
 
     void sessionDisconnected(Session session);
 
+    default void subscriptionEstablished(Session session, String topic) {}
+
+    default void subscriptionRemoved(Session session, String topic) {}
+
     boolean subscriptionRequested(Session session, String topic);
 }

--- a/server/src/main/java/dev/vepo/stomp4j/server/session/Session.java
+++ b/server/src/main/java/dev/vepo/stomp4j/server/session/Session.java
@@ -140,6 +140,7 @@ public class Session implements StompSession {
         }
         status = Status.END;
         stopHeartbeatTasks();
+        notifySubscriptionsRemoved();
         listener.sessionDisconnected(this);
         closer.close(this);
     }
@@ -200,6 +201,11 @@ public class Session implements StompSession {
                      .orElseThrow(() -> new IllegalStateException("No supported STOMP version in common"));
     }
 
+    private void notifySubscriptionsRemoved() {
+        subscriptions.forEach(subscription -> listener.subscriptionRemoved(this, subscription.topic()));
+        subscriptions.clear();
+    }
+
     public void offer(byte[] data, int length) {
         if (length <= 0) {
             return;
@@ -250,12 +256,17 @@ public class Session implements StompSession {
                 var ackMode = message.headers().get(Header.ACK);
                 if (listener.subscriptionRequested(this, topic)) {
                     subscriptions.add(new Subscription(topic, id, ackMode));
+                    listener.subscriptionEstablished(this, topic);
                 }
             }
             case UNSUBSCRIBE -> {
                 var id = message.headers().get(Header.ID);
                 var destination = message.headers().destination();
-                subscriptions.removeIf(subscription -> matchesUnsubscribe(subscription, id, destination));
+                var toRemove = subscriptions.stream()
+                                            .filter(subscription -> matchesUnsubscribe(subscription, id, destination))
+                                            .toList();
+                toRemove.forEach(subscription -> listener.subscriptionRemoved(this, subscription.topic()));
+                subscriptions.removeAll(toRemove);
             }
             case ACK -> acknowledgePendingMessage(message);
             case NACK -> negativeAcknowledgePendingMessage(message);

--- a/server/src/test/java/dev/vepo/stomp4j/server/tests/StompServerTest.java
+++ b/server/src/test/java/dev/vepo/stomp4j/server/tests/StompServerTest.java
@@ -27,6 +27,7 @@ import dev.vepo.stomp4j.client.protocol.v1_2.Stomp1_2;
 import dev.vepo.stomp4j.server.StompServer;
 import dev.vepo.stomp4j.server.SubscriberAckListener;
 import dev.vepo.stomp4j.server.StompSession;
+import dev.vepo.stomp4j.server.SubscriptionHandler;
 
 class StompServerTest {
     private record ReceivedMessage(String topic, String message) {}
@@ -163,6 +164,44 @@ class StompServerTest {
                             public void onNack(String messageId, StompSession session) {}
                         });
             await().until(ackReceived::get);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "stomp://localhost:5508" })
+    @DisplayName("Subscription handler should receive subscribe and unsubscribe lifecycle events")
+    @Timeout(value = 10, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    void subscriptionLifecycleTest(String url) {
+        var subscribed = new LinkedList<String>();
+        var unsubscribed = new LinkedList<String>();
+        try (var server = StompServer.builder()
+                                     .channel(TransportType.TCP, 5508)
+                                     .subscription(new SubscriptionHandler() {
+                                         @Override
+                                         public boolean accept(String topic) {
+                                             return true;
+                                         }
+
+                                         @Override
+                                         public void onSubscribed(StompSession session, String topic) {
+                                             subscribed.add(topic);
+                                         }
+
+                                         @Override
+                                         public void onUnsubscribed(StompSession session, String topic) {
+                                             unsubscribed.add(topic);
+                                         }
+                                     })
+                                     .handler(message -> {})
+                                     .start();
+                var client = StompClient.create(url)) {
+            client.connect();
+            var subscription = client.subscribe("topic-lifecycle");
+            await().until(() -> !subscribed.isEmpty());
+            assertThat(subscribed).containsExactly("topic-lifecycle");
+            client.unsubscribe(subscription);
+            await().until(() -> !unsubscribed.isEmpty());
+            assertThat(unsubscribed).containsExactly("topic-lifecycle");
         }
     }
 


### PR DESCRIPTION
- Introduced the `stomp4j-kafka-bridge` module for STOMP to Kafka routing.
- Added `KafkaBridgeConfig`, `DestinationMapper`, and related classes for configuration and mapping.
- Updated `pom.xml` to include Kafka dependencies and new modules.
- Enhanced `ARCHITECTURE.md` and `README.md` to document the Kafka bridge functionality.
- Created a new user guide for the Kafka bridge in `docs/kafka-bridge-guide.md`.
- Updated AGENTS.md to reflect the new Kafka bridge documentation requirements.